### PR TITLE
Improved the installation.bat

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -62,9 +62,10 @@ if not exist "%FFMPEG_DIR%" (
 
     REM Move contents from the extracted subfolder to the main ffmpeg dir
     for /d %%i in (ffmpeg_temp\*) do (
-        move "%%i" "%FFMPEG_DIR%"
+        move "%%i\*" "%FFMPEG_DIR%"
+        rmdir "%%i"
     )
-    rmdir ffmpeg_temp
+    rmdir "ffmpeg_temp"
     del "%FFMPEG_ZIP_FILE%"
     echo [SUCCESS] FFmpeg has been downloaded and extracted.
 ) else (
@@ -90,8 +91,7 @@ echo.
 
 REM 4. Activate virtual environment and install dependencies
 echo [STEP 4/5] Installing Python dependencies...
-call "%VENV_NAME%\Scripts\activate.bat"
-pip install -r requirements.txt
+call "%VENV_NAME%\Scripts\python.exe" -m pip install -r requirements.txt
 if %errorlevel% neq 0 (
     echo [ERROR] Failed to install dependencies from requirements.txt.
     exit /b 1


### PR DESCRIPTION
I found two primary issues in the `install.bat` script, which I have now resolved:

1.  **FFmpeg Extraction:** The script was incorrectly moving the entire FFmpeg directory after extraction, leading to an invalid PATH and preventing FFmpeg from being found. I corrected the logic to move the *contents* of the extracted directory instead, ensuring the `bin` folder is placed correctly.

2.  **Dependency Installation:** The script relied on `call activate.bat`, which can be unreliable for setting the environment context for subsequent commands in a batch file. I replaced this with a direct and more robust call to the Python executable within the created virtual environment (`venv\Scripts\python.exe -m pip install ...`).

These changes will make your Windows installation process more reliable.