### PR TITLE
Corrige el problema de visualización en la interfaz de comunicación s…

### DIFF
--- a/configuracion.html
+++ b/configuracion.html
@@ -55,9 +55,9 @@
                         <div class="mb-3">
                             <label for="machineModelSelect" class="form-label" data-i18n-key="settingsMachineModelLabel">Modelo de Máquina:</label>
                             <select class="form-select" id="machineModelSelect">
-                                <option value="S" data-i18n-key="settingsMachineModelS">Modelo S (10c, 20c, 50c, 1€)</option>
-                                <option value="M" selected data-i18n-key="settingsMachineModelM">Modelo M (5c a 2€)</option>
-                                <option value="MAX" data-i18n-key="settingsMachineModelMax">Modelo MAX (1c a 2€)</option>
+                                <option value="S" data-i18n-key="settingsMachineModelS">Modelo S (Básico)</option>
+                                <option value="M" selected data-i18n-key="settingsMachineModelM">Modelo M (Estándar)</option>
+                                <option value="MAX" data-i18n-key="settingsMachineModelMax">Modelo MAX (Completo)</option>
                             </select>
                         </div>
 

--- a/static/js/i18n.js
+++ b/static/js/i18n.js
@@ -39,6 +39,16 @@ const allTranslations = {
         "settingsLanguageLabel": "Idioma",
         "settingsLangSpanish": "Español",
         "settingsLangEnglish": "Inglés",
+        "settingsSerialTitle": "Comunicación con Dispositivo Externo",
+        "settingsSerialDescription": "Conecta un dispositivo por USB para enviar y recibir datos.",
+        "settingsMachineModelLabel": "Modelo de Máquina",
+        "settingsMachineModelS": "Modelo S (Básico)",
+        "settingsMachineModelM": "Modelo M (Estándar)",
+        "settingsMachineModelMax": "Modelo MAX (Completo)",
+        "settingsSerialConnect": "Conectar Dispositivo",
+        "settingsSerialSend": "Enviar",
+        "settingsSerialPlaceholder": "Escribe un comando...",
+        "settingsSerialConsoleLabel": "Consola de comunicación",
         "logoutButton": "Cerrar Sesión"
     },
     "en": {
@@ -81,6 +91,16 @@ const allTranslations = {
         "settingsLanguageLabel": "Language",
         "settingsLangSpanish": "Spanish",
         "settingsLangEnglish": "English",
+        "settingsSerialTitle": "External Device Communication",
+        "settingsSerialDescription": "Connect a device via USB to send and receive data.",
+        "settingsMachineModelLabel": "Machine Model",
+        "settingsMachineModelS": "Model S (Basic)",
+        "settingsMachineModelM": "Model M (Standard)",
+        "settingsMachineModelMax": "Model MAX (Complete)",
+        "settingsSerialConnect": "Connect Device",
+        "settingsSerialSend": "Send",
+        "settingsSerialPlaceholder": "Type a command...",
+        "settingsSerialConsoleLabel": "Communication console",
         "logoutButton": "Log Out"
     }
 };


### PR DESCRIPTION
…erial y mejora las descripciones de los modelos de máquina.

- Añade las traducciones que faltaban en español e inglés al archivo `static/js/i18n.js` para todos los nuevos elementos de la interfaz.
- Actualiza el texto por defecto en las opciones del selector de modelo en `configuracion.html` para que sea más profesional y coherente con las nuevas traducciones (ej. "Modelo S (Básico)").

Esto resuelve el problema por el que se mostraban las claves de internacionalización en lugar del texto real y atiende a la solicitud del usuario de tener descripciones más profesionales.