### PR TITLE
Fix: Vercel not_found error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,13 @@
 {
   "version": 2,
   "public": "docs",
-  "builds": [
-    { "src": "/*", "use": "@vercel/static" }
+  "routes": [
+    { "src": "/assets/(.*)", "dest": "/assets/$1" },
+    { "src": "/configuracion", "dest": "/configuracion.html" },
+    { "src": "/forgot_password", "dest": "/forgot_password.html" },
+    { "src": "/history", "dest": "/history.html" },
+    { "src": "/login", "dest": "/login.html" },
+    { "src": "/signup", "dest": "/signup.html" },
+    { "src": "/", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
Updated the `vercel.json` file to correctly handle routing for the static site. Removed the `builds` section and added a `routes` section to map URL paths to their corresponding HTML files. This ensures that Vercel can correctly resolve the routes and serve the appropriate files, fixing the `not_found` error.