### PR TITLE
Fix: Vercel not_found error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,12 @@
 {
   "version": 2,
-  "public": "docs",
-  "routes": [
-    { "src": "/assets/(.*)", "dest": "/assets/$1" },
-    { "src": "/configuracion", "dest": "/configuracion.html" },
-    { "src": "/forgot_password", "dest": "/forgot_password.html" },
-    { "src": "/history", "dest": "/history.html" },
-    { "src": "/login", "dest": "/login.html" },
-    { "src": "/signup", "dest": "/signup.html" },
-    { "src": "/", "dest": "/index.html" }
+  "outputDirectory": "docs",
+  "rewrites": [
+    { "source": "/configuracion", "destination": "/configuracion.html" },
+    { "source": "/forgot_password", "destination": "/forgot_password.html" },
+    { "source": "/history", "destination": "/history.html" },
+    { "source": "/login", "destination": "/login.html" },
+    { "source": "/signup", "destination": "/signup.html" },
+    { "source": "/", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
Updated the `vercel.json` file to correctly handle routing for the static site. Replaced the legacy `routes` property with the recommended `rewrites` property to map URL paths to their corresponding HTML files. This ensures that Vercel can correctly resolve the routes and serve the appropriate files, fixing the `not_found` error. Also, updated the `public` property to its modern alias `outputDirectory` for clarity.