### PR TITLE
Fix: Handle time-like format from speech recognition

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -433,6 +433,16 @@ function parseSpanishAmount(text) {
     if (!text) return null;
 
     let normalizedText = text.toLowerCase().trim();
+
+    // Handle time-like format from speech recognition e.g., "5:50"
+    const timeMatch = normalizedText.match(/(\d{1,2}):(\d{2})/);
+    if (timeMatch) {
+        const potentialNumber = timeMatch[0].replace(':', '.');
+        const val = parseFloat(potentialNumber);
+        if (!isNaN(val)) {
+            return parseFloat(val.toFixed(2));
+        }
+    }
     // Normalize currency symbols and common words, but leave "y" alone for now.
     normalizedText = normalizedText.replace(/€/g, ' euros ');
     normalizedText = normalizedText.replace(/centimo[s]?/g, ' centimos ');


### PR DESCRIPTION
The speech recognition engine sometimes misinterprets spoken currency amounts (e.g., "cinco cincuenta") as a time format (e.g., "5:50").

This was causing the application to parse the amount incorrectly, typically only taking the number before the colon.

This commit adds logic to the `parseSpanishAmount` function to detect and correctly parse this time-like format, converting "5:50" into the decimal number 5.50. This makes the voice input feature more robust to the inconsistencies of the underlying speech-to-text engine.