### PR TITLE
Fix: CI timeout by ensuring server starts correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,15 @@ jobs:
       - name: Start Flask server
         run: |
           source venv/bin/activate
-          flask --app app run --host=0.0.0.0 &
+          python vercel.py > server.log 2>&1 &
 
       - name: Wait for server to be ready
         run: npx wait-on http://localhost:5000/ --timeout 60000
+
+      - name: Display server log
+        if: always()
+        run: |
+          cat server.log || echo "server.log not found"
 
       - name: Run Playwright tests
         run: npm test

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,11 @@ def get_locale():
         return session['language']
     return request.accept_languages.best_match(list(LANGUAGES.keys()))
 
+@app.context_processor
+def inject_get_locale():
+    """Inject get_locale function into all templates."""
+    return dict(get_locale=get_locale)
+
 # Initialize the app
 app = Flask(__name__, instance_relative_config=True)
 

--- a/vercel.py
+++ b/vercel.py
@@ -2,4 +2,5 @@
 # It imports the Flask app instance from our 'app' package.
 from app import app
 
-# No content here, effectively deleting the block
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
The CI job was failing because the server was not starting correctly, leading to a timeout.

This commit addresses the issue by:
1.  Creating a dedicated entry point for the Flask application in `vercel.py` that binds the server to `0.0.0.0`.
2.  Updating the CI workflow to use this entry point (`python vercel.py`) to start the server.
3.  Adding logging for the server startup process to aid future debugging.