### PR TITLE
fix(app): Resolve NameError in app initialization

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,13 +17,13 @@ def get_locale():
         return session['language']
     return request.accept_languages.best_match(list(LANGUAGES.keys()))
 
+# Initialize the app
+app = Flask(__name__, instance_relative_config=True)
+
 @app.context_processor
 def inject_get_locale():
     """Inject get_locale function into all templates."""
     return dict(get_locale=get_locale)
-
-# Initialize the app
-app = Flask(__name__, instance_relative_config=True)
 
 # --- Configuration ---
 app.config.from_mapping(


### PR DESCRIPTION
The @app.context_processor decorator was being called before the Flask `app` instance was created, causing a `NameError` on startup.

This commit moves the decorator to after the app's initialization, ensuring that the `app` object exists before it is used. This resolves the error while preserving the original structure of the application.