### PR TITLE
feat: Use replaceAll for global string replacement

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,8 +35,8 @@ export default function Home() {
     const parseVoiceInput = (text: string) => {
         const numbers = text.match(/[\d]+([.,][\d]+)?/g);
         if (numbers && numbers.length >= 2) {
-            setReceived(numbers[0].replace(',', '.'));
-            setTotal(numbers[1].replace(',', '.'));
+            setReceived(numbers[0].replaceAll(',', '.'));
+            setTotal(numbers[1].replaceAll(',', '.'));
             // Auto-calculate after state updates (need a way to trigger sync calculation or use effect)
         }
     };
@@ -136,7 +136,7 @@ export default function Home() {
 
             <div className="result-box">
                 <span className="text-muted">
-                    {t('changeResultText').replace('{change}', result !== null ? result.toFixed(2) : '--')}
+                {t('changeResultText').replaceAll('{change}', result !== null ? result.toFixed(2) : '--')}
                 </span>
                 <span id="result-value" className="result-value">
                     {result !== null ? `€ ${result.toFixed(2)}` : '--'}


### PR DESCRIPTION
Replaced `replace()` with `replaceAll()` in `src/app/page.tsx` and `src/lib/i18n.tsx` to ensure all instances of a substring are replaced, not just the first. This improves the robustness of the decimal conversion and placeholder replacement logic.